### PR TITLE
pass the block explicitly

### DIFF
--- a/lib/onelogin/api/cursor.rb
+++ b/lib/onelogin/api/cursor.rb
@@ -30,7 +30,7 @@ class Cursor
     @after_cursor = options.fetch(:after_cursor, nil)
   end
 
-  def each(start = 0)
+  def each(start = 0, &proc)
     return to_enum(:each, start) unless block_given?
 
     Array(@collection[start..-1]).each do |item|
@@ -46,7 +46,7 @@ class Cursor
 
       fetch_next_page
 
-      each(start, &Proc.new)
+      each(start, &proc)
     end
   end
 


### PR DESCRIPTION
I using this gem, and I got this message.

```
vendor/bundle/ruby/2.7.0/gems/onelogin-1.5.0/lib/onelogin/api/cursor.rb:49: warning: Capturing the given block using Proc.new is deprecated; use `&block` instead
```
In ruby 2.7, it causes a bug, so a warning is displayed.
https://bugs.ruby-lang.org/issues/15539

